### PR TITLE
chore: bump speakeasy and generate

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,21 +1,21 @@
 lockVersion: 2.0.0
 id: 8a4eac39-6713-4ddc-9ce6-7a233c1cb864
 management:
-  docChecksum: a124128ede7599210169eec3aec3b0f4
-  docVersion: 3.16.0
-  speakeasyVersion: 1.761.9
-  generationVersion: 2.881.4
+  docChecksum: 70ac65006155e32074bd9deae1a2031b
+  docVersion: 3.15.0
+  speakeasyVersion: 1.788.0
+  generationVersion: 2.915.0
   releaseVersion: 1.1.0
   configChecksum: c090f812f51275522b56f8ba9fd0ca61
 persistentEdits:
-  generation_id: 2acb7bf7-7a3e-4489-a22c-f1adb7cb4b2f
-  pristine_commit_hash: fdaaa2f06faa664dd2f07ad5262c5f262395f918
-  pristine_tree_hash: 92a0cd1009888dd95d202217d54b864a504f8656
+  generation_id: 67101db6-aed1-4dc7-8405-f5ff1ae72b5e
+  pristine_commit_hash: 6a66fa0e63f3561c629c14425309c783350dede6
+  pristine_tree_hash: 5908c4b82f3d02c09a225d396e8240a159bf4585
 features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.3.2
-    core: 3.47.4
+    core: 3.47.10
     globalSecurity: 2.82.3
     globalServerURLs: 2.83.2
     inputOutputModels: 2.83.0
@@ -1732,8 +1732,8 @@ trackedFiles:
     pristine_git_object: 28c7e1cffe60ba2f3c8cb783dce79fc928934496
   go.mod:
     id: c47645c391ad
-    last_write_checksum: sha1:afb0e5bd6934577c61b3cbf19875d3420a9a1c1f
-    pristine_git_object: ea04611f9ae805bb98bb49d075797e2ee68c30b3
+    last_write_checksum: sha1:c548c97f8343a734119f048effb6d6fcab7cd82c
+    pristine_git_object: 9e54a949b43797eb098076bf865e07a80bdb0b54
   internal/planmodifiers/boolplanmodifier/suppress_diff.go:
     id: 3cf85b98963e
     last_write_checksum: sha1:263e1cf5d14ed18c531ecfd6cfee477db3f58032
@@ -4440,8 +4440,8 @@ trackedFiles:
     pristine_git_object: 24827e92d9ceb6d7a3eea097902ed1b309bc5e14
   internal/sdk/internal/utils/json.go:
     id: 2231afac3add
-    last_write_checksum: sha1:d5d9893986b79451eafff59f7c90f3ffe5786bd0
-    pristine_git_object: 65dc8b28962514f36cdcc08da263df0d5da829c1
+    last_write_checksum: sha1:c5851dfaef83affcd3bb8028281f175b1bbe59f7
+    pristine_git_object: 548223f89026666ca9814f71b09f410cf2045104
   internal/sdk/internal/utils/pathparams.go:
     id: e7fec2afe4a6
     last_write_checksum: sha1:051a84908bb441f00ec77062efabd5cb0a323968
@@ -4464,12 +4464,12 @@ trackedFiles:
     pristine_git_object: a2332ee8de013a2121880e4b7be332d3385c6f41
   internal/sdk/internal/utils/union.go:
     id: 183142835cfe
-    last_write_checksum: sha1:05b1939d2e574f765dafc88806262d9a2703cf73
-    pristine_git_object: 6be7a4422ddd643038dbac57e542a0dd5194f1ef
+    last_write_checksum: sha1:fd25fd7873f4dd9c09c1d497ad0824d7831f666b
+    pristine_git_object: 5ba0f96412073102688ba1d0679a420d20f34cfc
   internal/sdk/internal/utils/union_test.go:
     id: 4c885192f6f0
-    last_write_checksum: sha1:83ac73c1901de4c6db90f65cf5879163f3d47a00
-    pristine_git_object: f66814c73ace94d8e71d785fd6161fb405745754
+    last_write_checksum: sha1:bd5c7506e1d6238117c1ac4e340314a5a41401b5
+    pristine_git_object: 138f7e2a066b10dffd0a9957ecfcab9e00dd26fe
   internal/sdk/internal/utils/utils.go:
     id: feefcdf75dbd
     last_write_checksum: sha1:c03378176a107205b8938606faef3fd8fb8f91a0
@@ -4488,8 +4488,8 @@ trackedFiles:
     pristine_git_object: 402553581b4b2f6e6f1195534cb873908698b074
   internal/sdk/konggateway.go:
     id: "00e542406092"
-    last_write_checksum: sha1:d3e42d3ac5e1ebb230b7c544a1cdad164338a0d8
-    pristine_git_object: c523a98adc8b345a4df93b2f6720eb38c9fc2e0c
+    last_write_checksum: sha1:302fde3e35ee6fdd36ec63c292abe0a42e4ba653
+    pristine_git_object: c3ac7f891daf57ee8c2b5eb9247139e7c0b8514a
   internal/sdk/models/errors/sdkerror.go:
     id: 19b5a8d3586b
     last_write_checksum: sha1:5d65fce5049df7c5113e11c9ccb1e4c46b91901c
@@ -7436,8 +7436,8 @@ trackedFiles:
     pristine_git_object: dbc25240130cde59c72f857d8fa75cb7a8bbcdc5
   internal/sdk/retry/config.go:
     id: 7ea5fa9128b6
-    last_write_checksum: sha1:7f7d96b59a18e95bac847ae09c63bbd911ee8432
-    pristine_git_object: 5b3dc7c122d8ab08905485342d7474f8f163888d
+    last_write_checksum: sha1:102d1953fbd7e9f312c4442c71ccca2eaaeaa27d
+    pristine_git_object: 767002c7898128324d8741ce9c534bd466492169
   internal/sdk/routes.go:
     id: d87401733f23
     last_write_checksum: sha1:4d0cb2f779d58af4f77badf2134fcc9c95b0db9e

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.761.9
+speakeasyVersion: 1.788.0
 sources:
     Gateway:
         sourceNamespace: gateway
@@ -26,7 +26,7 @@ targets:
         sourceBlobDigest: sha256:4480283a1eae9bdc25755a33276e40d3767af38725f68cb2dcfe39662a72ae68
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.761.9
+    speakeasyVersion: 1.788.0
     sources:
         gateway:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.761.9
+speakeasyVersion: 1.788.0
 sources:
   gateway:
     inputs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/terraform-provider-kong-gateway
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/hashicorp/go-uuid v1.0.3

--- a/internal/sdk/internal/utils/json.go
+++ b/internal/sdk/internal/utils/json.go
@@ -512,6 +512,13 @@ func unmarshalValue(value json.RawMessage, v reflect.Value, tag reflect.StructTa
 			return nil
 		}
 	case reflect.Map:
+		if implementsJSONUnmarshaler(v.Type()) {
+			if v.CanAddr() {
+				return json.Unmarshal(value, v.Addr().Interface())
+			}
+			return json.Unmarshal(value, v.Interface())
+		}
+
 		if bytes.Equal(value, []byte("null")) || !isComplexValueType(dereferenceTypePointer(typ.Elem())) {
 			if v.CanAddr() {
 				return json.Unmarshal(value, v.Addr().Interface())

--- a/internal/sdk/internal/utils/union.go
+++ b/internal/sdk/internal/utils/union.go
@@ -128,8 +128,8 @@ func countFieldsRecursive(candidate *UnionCandidate, typ reflect.Type, val refle
 
 	// Handle unions
 	if isUnion, activeVariant, variantVal := findActiveUnionVariant(typ, val); isUnion {
-		if activeVariant != nil && !variantVal.IsNil() {
-			countFieldsRecursive(candidate, activeVariant.Type.Elem(), variantVal.Elem(), raw)
+		if activeVariant != nil {
+			countFieldsRecursive(candidate, activeVariant.Type, variantVal, raw)
 		}
 		return
 	}
@@ -253,7 +253,6 @@ func findActiveUnionVariant(typ reflect.Type, val reflect.Value) (bool, *reflect
 
 		isUnion = true
 
-		// All union variants are pointers - only set active if non-nil
 		fieldVal := val.Field(i)
 		if !fieldVal.IsNil() {
 			activeVariant = &field

--- a/internal/sdk/internal/utils/union_test.go
+++ b/internal/sdk/internal/utils/union_test.go
@@ -585,3 +585,73 @@ func TestPickBestUnionCandidate_AnyFieldType(t *testing.T) {
 	require.NotNil(t, result)
 	assert.IsType(t, B{}, result.Type)
 }
+
+func TestPickBestUnionCandidate_NonPointerUnionVariants(t *testing.T) {
+	type Inner struct {
+		Foo string `json:"foo"`
+	}
+	type SliceUnion struct {
+		AsObject *Inner   `union:"member"`
+		AsList   []string `union:"member"`
+	}
+	type MapUnion struct {
+		AsObject *Inner            `union:"member"`
+		AsMap    map[string]string `union:"member"`
+	}
+	type AnyUnion struct {
+		AsObject *Inner `union:"member"`
+		AsAny    any    `union:"member"`
+	}
+
+	cases := []struct {
+		name       string
+		payload    string
+		candidates []UnionCandidate
+		wantType   string
+	}{
+		{
+			name:    "slice variant wins for array payload",
+			payload: `["a", "b"]`,
+			candidates: []UnionCandidate{
+				{Type: "object", Value: SliceUnion{AsObject: &Inner{}}},
+				{Type: "list", Value: SliceUnion{AsList: []string{"a", "b"}}},
+			},
+			wantType: "list",
+		},
+		{
+			name:    "map variant wins for object payload with no matching struct fields",
+			payload: `{"k1": "v1", "k2": "v2"}`,
+			candidates: []UnionCandidate{
+				{Type: "object", Value: MapUnion{AsObject: &Inner{}}},
+				{Type: "map", Value: MapUnion{AsMap: map[string]string{"k1": "v1", "k2": "v2"}}},
+			},
+			wantType: "map",
+		},
+		{
+			name:    "any variant wins as catch-all when struct can't fit a scalar",
+			payload: `"scalar"`,
+			candidates: []UnionCandidate{
+				{Type: "object", Value: AnyUnion{AsObject: &Inner{}}},
+				{Type: "any", Value: AnyUnion{AsAny: "scalar"}},
+			},
+			wantType: "any",
+		},
+		{
+			name:    "structured variant beats any on a matching object payload",
+			payload: `{"foo": "x"}`,
+			candidates: []UnionCandidate{
+				{Type: "object", Value: AnyUnion{AsObject: &Inner{Foo: "x"}}},
+				{Type: "any", Value: AnyUnion{AsAny: map[string]any{"foo": "x"}}},
+			},
+			wantType: "object",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := PickBestUnionCandidate(tc.candidates, []byte(tc.payload))
+			require.NotNil(t, result)
+			assert.Equal(t, tc.wantType, result.Type)
+		})
+	}
+}

--- a/internal/sdk/konggateway.go
+++ b/internal/sdk/konggateway.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 3.16.0 and generator version 2.881.4
+// Generated from OpenAPI doc version 3.15.0 and generator version 2.915.0
 
 import (
 	"context"
@@ -319,7 +319,7 @@ func New(opts ...SDKOption) *KongGateway {
 	sdk := &KongGateway{
 		SDKVersion: "1.1.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.1.0 2.881.4 3.16.0 github.com/kong/terraform-provider-kong-gateway/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.1.0 2.915.0 3.15.0 github.com/kong/terraform-provider-kong-gateway/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: []map[string]string{
 				{

--- a/internal/sdk/retry/config.go
+++ b/internal/sdk/retry/config.go
@@ -98,6 +98,14 @@ func retryIntervalFromResponse(res *http.Response) time.Duration {
 		return 0
 	}
 
+	retryAfterMsVal := res.Header.Get("retry-after-ms")
+	if retryAfterMsVal != "" {
+		parsedMs, err := strconv.ParseInt(retryAfterMsVal, 10, 64)
+		if err == nil && parsedMs >= 0 {
+			return time.Duration(parsedMs) * time.Millisecond
+		}
+	}
+
 	retryVal := res.Header.Get("retry-after")
 	if retryVal == "" {
 		return 0


### PR DESCRIPTION
### Summary
In this PR we are bumping speakeasy to v1.788.0
  
### Issues resolved
-

### Related PRs (if any)
-

### Checklist ✅ 
- [ ] Added/updated examples (if applicable)  
- [ ] Added/updated acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md` to clearly mention any breaking changes, new features and bug fixes
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
